### PR TITLE
[only in this fork] forgejo: refactor to ease overriding

### DIFF
--- a/pkgs/by-name/fo/forgejo/generic.nix
+++ b/pkgs/by-name/fo/forgejo/generic.nix
@@ -1,28 +1,30 @@
-{ lts ? false
-, version
-, hash
-, npmDepsHash
-, vendorHash
-, nixUpdateExtraArgs ? [ ]
+{
+  lts ? false,
+  version,
+  hash,
+  npmDepsHash,
+  vendorHash,
+  nixUpdateExtraArgs ? [ ],
 }:
 
-{ bash
-, brotli
-, buildGoModule
-, forgejo
-, git
-, gzip
-, lib
-, makeWrapper
-, nix-update-script
-, nixosTests
-, openssh
-, sqliteSupport ? true
-, xorg
-, runCommand
-, stdenv
-, fetchFromGitea
-, buildNpmPackage
+{
+  bash,
+  brotli,
+  buildGoModule,
+  forgejo,
+  git,
+  gzip,
+  lib,
+  makeWrapper,
+  nix-update-script,
+  nixosTests,
+  openssh,
+  sqliteSupport ? true,
+  xorg,
+  runCommand,
+  stdenv,
+  fetchFromGitea,
+  buildNpmPackage,
 }:
 
 let
@@ -56,11 +58,17 @@ buildGoModule rec {
     version
     src
     vendorHash
-  ;
+    ;
 
-  subPackages = [ "." "contrib/environment-to-ini" ];
+  subPackages = [
+    "."
+    "contrib/environment-to-ini"
+  ];
 
-  outputs = [ "out" "data" ];
+  outputs = [
+    "out"
+    "data"
+  ];
 
   nativeBuildInputs = [
     makeWrapper
@@ -79,7 +87,10 @@ buildGoModule rec {
     substituteInPlace modules/setting/server.go --subst-var data
   '';
 
-  tags = lib.optionals sqliteSupport [ "sqlite" "sqlite_unlock_notify" ];
+  tags = lib.optionals sqliteSupport [
+    "sqlite"
+    "sqlite_unlock_notify"
+  ];
 
   ldflags = [
     "-s"
@@ -124,29 +135,44 @@ buildGoModule rec {
     mkdir -p $out
     cp -R ./options/locale $out/locale
     wrapProgram $out/bin/gitea \
-      --prefix PATH : ${lib.makeBinPath [ bash git gzip openssh ]}
+      --prefix PATH : ${
+        lib.makeBinPath [
+          bash
+          git
+          gzip
+          openssh
+        ]
+      }
   '';
 
   # $data is not available in goModules.drv
-  overrideModAttrs = (_: {
-    postPatch = null;
-  });
+  overrideModAttrs = (
+    _: {
+      postPatch = null;
+    }
+  );
 
   passthru = {
     # allow nix-update to handle npmDepsHash
     inherit (frontend) npmDeps;
 
-    data-compressed = runCommand "forgejo-data-compressed" {
-      nativeBuildInputs = [ brotli xorg.lndir ];
-    } ''
-      mkdir $out
-      lndir ${forgejo.data}/ $out/
+    data-compressed =
+      runCommand "forgejo-data-compressed"
+        {
+          nativeBuildInputs = [
+            brotli
+            xorg.lndir
+          ];
+        }
+        ''
+          mkdir $out
+          lndir ${forgejo.data}/ $out/
 
-      # Create static gzip and brotli files
-      find -L $out -type f -regextype posix-extended -iregex '.*\.(css|html|js|svg|ttf|txt)' \
-        -exec gzip --best --keep --force {} ';' \
-        -exec brotli --best --keep --no-copy-stat {} ';'
-    '';
+          # Create static gzip and brotli files
+          find -L $out -type f -regextype posix-extended -iregex '.*\.(css|html|js|svg|ttf|txt)' \
+            -exec gzip --best --keep --force {} ';' \
+            -exec brotli --best --keep --no-copy-stat {} ';'
+        '';
 
     tests = if lts then nixosTests.forgejo-lts else nixosTests.forgejo;
     updateScript = nix-update-script { extraArgs = nixUpdateExtraArgs; };
@@ -157,7 +183,12 @@ buildGoModule rec {
     homepage = "https://forgejo.org";
     changelog = "https://codeberg.org/forgejo/forgejo/releases/tag/${src.rev}";
     license = lib.licenses.mit;
-    maintainers = with lib.maintainers; [ emilylange urandom bendlas adamcstephens ];
+    maintainers = with lib.maintainers; [
+      emilylange
+      urandom
+      bendlas
+      adamcstephens
+    ];
     broken = stdenv.isDarwin;
     mainProgram = "gitea";
   };

--- a/pkgs/by-name/fo/forgejo/generic.nix
+++ b/pkgs/by-name/fo/forgejo/generic.nix
@@ -1,12 +1,12 @@
 {
   lts ? false,
-  version,
-  rev ? null,
-  srcOverride ? null,
-  hash,
+  version, # used as revision if 'rev' is not given
+  rev ? null, # specify this to use a different revision than the version directly. Included later in version string.
+  source ? null, # to override the entire forgejo source. Don't use overrideAttrs for this!
+  hash ? "", # specify if you don't specify source
   npmDepsHash,
   vendorHash,
-  extraRuntimeInputs ? [ ],
+  extraRuntimeInputs ? [ ], # list of packages the forgejo executable should have access to
   nixUpdateExtraArgs ? [ ],
 }:
 
@@ -33,8 +33,8 @@
 let
   versionString = if builtins.isString rev then "${version}-${rev}" else version;
   src =
-    if !builtins.isNull srcOverride then
-      srcOverride
+    if !builtins.isNull source then
+      source
     else
       fetchFromGitea {
         domain = "codeberg.org";


### PR DESCRIPTION
## Description of changes
                                                                            
Introduce new optional arguments to `forgejo/generic.nix`:                  
                                                                            
- `rev`: git revision to use, will also be included in the version string.  
- `srcOverride`: for overriding the entire forgejo source.                  
  Note that `overrideAttrs` does not work for this as the frontend npm      
  package must use the same src as the go module but has its source         
  specified in an un-overridable let-binding.                               
- `extraRuntimeInputs`: list of additional packages the forgejo             
  executable should have access to during runtime, e.g. for custom          
  renderers or other extensions (e.g. git-annex).                           

These changes enable overriding the forgejo package to use a specific version or fork and add runtime dependencies without copy-pasting the `generic.nix` from nixpkgs or using a nixpkgs fork entirely, for example:

```nix
  forgejo-aneksajo = (pkgs.callPackage (import
    <nixpkgs/pkgs/by-name/fo/forgejo/generic.nix> rec {
      version = "8.0.2-git-annex0";
      rev = "b62d89ce67";
      hash = "sha256-kjvTPT5Iw2rm3ksP+9mm1tQOTLtr8T2Zikw5dl6aFWI=";
      srcOverride = pkgs.fetchFromGitea {
        domain = "codeberg.org";
        owner = "nobodyinperson";
        repo = "forgejo-aneksajo";
        inherit rev hash;
      };
      npmDepsHash = "sha256-dIf1Sh0jrQPM2IY+VtTtrEioBM1r43mQEI0fG4DcGTc=";
      vendorHash = "sha256-4l4kscwesW/cR8mZjE3G9HcVm0d1ukxbtBY6RXYRi8k=";
      lts = false;
      extraRuntimeInputs = [ pkgs.git-annex ]; # for annex support
    }) { }).overrideAttrs (oldAttrs: { doCheck = false; });
```

The `forgejo` and `forgejo-lts` packages still evaluate to the same, so no rebuild should be necessary. 

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [x] Tested, as applicable:
  - [x] [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
    - [x] `nix-build -A nixosTests.forgejo`
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
    - [x] `nix-build -A pkgs.forgejo.passthru.tests`
    - [x] `nix-build -A pkgs.forgejo-lts.passthru.tests`
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#linking-nixos-module-tests-to-a-package) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
